### PR TITLE
husky install が失敗してもエラーにならないように

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint:text:dry-run": "textlint --cache --fix --dry-run --format diff .",
     "format": "prettier --write .",
     "test": "jest",
-    "prepare": "husky install"
+    "prepare": "husky install || [ $? = 127 ]"
   },
   "dependencies": {
     "next": "12.1.6",


### PR DESCRIPTION
#40 の修正

husky install がコード 127 を返したときに 0 を返すように
