### PR TITLE
Draft PR 作成アクションを追加

### DIFF
--- a/.github/workflows/auto_pr.yml
+++ b/.github/workflows/auto_pr.yml
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: MIT
+
+name: Auto PR
+
+on: create
+
+jobs:
+  pr:
+    if: github.event.ref_type == 'branch' && ! github.event.repository.fork
+    name: Create PR
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup git
+        run: |
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config push.default current
+      - name: Create a pull request
+        run: |
+          ISSUE=`echo "${{ github.event.ref }}" | grep -oE '#[0-9]+'`
+          if ${{ startsWith(github.event.ref, 'hotfix/') }}; then
+            if git diff --quiet origin/main; then
+              git commit --allow-empty -m "empty commit"
+              git push
+            fi
+            gh pr create --draft --base main --assignee ${{ github.event.sender.login }} --title "${{ github.event.ref }}" --body "close $ISSUE"
+          else
+            if git diff --quiet origin/develop; then
+              git commit --allow-empty -m "empty commit"
+              git push
+            fi
+            gh pr create --draft --base develop --assignee ${{ github.event.sender.login }} --title "${{ github.event.ref }}" --body "close $ISSUE"
+          fi


### PR DESCRIPTION
close #57 

#XX が含まれたブランチを作成した場合、Draft PR を作成するようにした。
- ブランチ名を仮の状態で作りたい場合は一旦 Issue番号なしの状態でブランチを作り、あとからブランチ名変更をする。