### PR TITLE
JavaScript の記法を統一するリファクタリング

### DIFF
--- a/components/base/image.jsx
+++ b/components/base/image.jsx
@@ -4,6 +4,8 @@ const customLoader = ({ src }) => {
   return src;
 };
 
-export default function Image(props) {
+const Image = ({ ...props }) => {
   return <NextImage {...props} loader={customLoader} />;
-}
+};
+
+export default Image;

--- a/components/base/image.jsx
+++ b/components/base/image.jsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+
+// components
 import NextImage from "next/image";
 
 const customLoader = ({ src }) => {

--- a/components/base/link.jsx
+++ b/components/base/link.jsx
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 
+// components
 import NextLink from "next/link";
 
 const Link = ({ href, children, ...props }) => {

--- a/components/base/link.jsx
+++ b/components/base/link.jsx
@@ -8,7 +8,9 @@ const Link = ({ href, children, ...props }) => {
   if (href.startsWith("/") || href === "")
     return (
       <NextLink href={href}>
-        <a {...props}>{children}</a>
+        <a href={href} {...props}>
+          {children}
+        </a>
       </NextLink>
     );
   // external link

--- a/components/base/link.jsx
+++ b/components/base/link.jsx
@@ -2,9 +2,7 @@
 
 import NextLink from "next/link";
 
-const Link = (props) => {
-  const { href, children } = props;
-
+const Link = ({ href, children, ...props }) => {
   // internal link
   if (href.startsWith("/") || href === "")
     return (

--- a/components/countdown.jsx
+++ b/components/countdown.jsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-// next
+// react
 import React from "react";
 // styles
 import styles from "./countdown.module.scss";

--- a/components/layout/header.jsx
+++ b/components/layout/header.jsx
@@ -2,6 +2,7 @@
 
 // react
 import React from "react";
+// hooks
 import { useMediaQuery } from "react-responsive";
 // components
 import Link from "@/components/base/link";

--- a/components/layout/menu.jsx
+++ b/components/layout/menu.jsx
@@ -2,6 +2,7 @@
 
 // react
 import React from "react";
+// next
 import Router from "next/router";
 // components
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-// next
+// hooks
 import { useRouter } from "next/router";
 // components
 import { DefaultSeo } from "next-seo";


### PR DESCRIPTION
# コメント関連

## import

1. react
2. next
3. hooks
4. components
5. styles
6. icons
7. config

の順番で、それぞれ適切なコメントの所で import するように。
(今後別のカテゴリが増える可能性はあるが、とりあえず。)

## `SPDX-License-Identifier`

`/components/base/image.jsx` につけ忘れていたので付けた。

# コンポーネント関連

## props

[一番文句言われなさそうな React コンポーネントの書き方](https://zenn.dev/seya/articles/0317b7a61ee781)

この記事を参考に、

```jsx
const Hoge = ({ children, ...props }) => {
  return (
    <div {...props}>{children}</div>
  );
};
```

というような書き方で統一する。

記事では TypeScript ならではの理由でこのように結論付けている部分もあり、
このプロジェクトは TypeScript ではなく JavaScript (と一部 JSDoc) だが、
だからといってわざわざ記事の書き方に対抗する必要はないと判断したため、記事に揃えることに。

## export

`export` は定義と同時ではなく最後にまとめた。
このほうが、結局なにが export されてるのかが後ろにまとまってわかりやすいためである。