### PR TITLE
`next-compose-plugins`を廃止しwarnが出る問題を修正

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 /** @type {import("next").NextConfig} */
-const nextConfig = {
+let config = {
   reactStrictMode: true,
   pageExtensions: ["js", "jsx", "md", "mdx"],
   images: {
@@ -9,19 +9,16 @@ const nextConfig = {
   },
 };
 
-module.exports = () => {
-  const plugins = [
-    require("@next/mdx")({
-      extension: /\.mdx?$/,
-      options: {
-        remarkPlugins: [],
-        rehypePlugins: [],
-        // If you use `MDXProvider`, uncomment the following line.
-        // providerImportSource: "@mdx-js/react",
-      },
-    }),
-  ];
-  return plugins.reduce((acc, plugin) => plugin(acc), {
-    ...nextConfig,
-  });
-};
+config = require("@next/mdx")({
+  extension: /\.mdx?$/,
+  options: {
+    remarkPlugins: [],
+    rehypePlugins: [],
+    // If you use `MDXProvider`, uncomment the following line.
+    // providerImportSource: "@mdx-js/react",
+  },
+})(config);
+
+console.log(config);
+
+module.exports = () => config;

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-const withPlugins = require("next-compose-plugins");
-
 /** @type {import("next").NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -11,17 +9,19 @@ const nextConfig = {
   },
 };
 
-const plugins = [];
-
-plugins.push([
-  require("@next/mdx")({
-    extension: /\.mdx?$/,
-    options: {
-      remarkPlugins: [],
-      rehypePlugins: [],
-      // If you use `MDXProvider`, uncomment the following line.
-      // providerImportSource: "@mdx-js/react",
-    },
-  }),
-]);
-module.exports = withPlugins(plugins, nextConfig);
+module.exports = () => {
+  const plugins = [
+    require("@next/mdx")({
+      extension: /\.mdx?$/,
+      options: {
+        remarkPlugins: [],
+        rehypePlugins: [],
+        // If you use `MDXProvider`, uncomment the following line.
+        // providerImportSource: "@mdx-js/react",
+      },
+    }),
+  ];
+  return plugins.reduce((acc, plugin) => plugin(acc), {
+    ...nextConfig,
+  });
+};

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@mdx-js/loader": "2.1.2",
     "@next/mdx": "12.2.3",
     "next": "12.2.3",
-    "next-compose-plugins": "2.2.1",
     "next-seo": "5.5.0",
     "npm-run-all": "4.1.5",
     "react": "18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,6 @@ specifiers:
   jest-environment-jsdom: 28.1.3
   lint-staged: 13.0.3
   next: 12.2.3
-  next-compose-plugins: 2.2.1
   next-seo: 5.5.0
   npm-run-all: 4.1.5
   prettier: 2.7.1
@@ -59,7 +58,6 @@ dependencies:
   '@mdx-js/loader': 2.1.2_webpack@5.73.0
   '@next/mdx': 12.2.3_todqhrvd7cvbb36hzi2r6xttgq
   next: 12.2.3_2ripihjq6lppj6jnclx3dq3pdi
-  next-compose-plugins: 2.2.1
   next-seo: 5.5.0_53oqlnqnxhbetdy4ljlkkvmoby
   npm-run-all: 4.1.5
   react: 18.2.0
@@ -5247,10 +5245,6 @@ packages:
 
   /neo-async/2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
-    dev: false
-
-  /next-compose-plugins/2.2.1:
-    resolution: {integrity: sha512-OjJ+fV15FXO2uQXQagLD4C0abYErBjyjE0I0FHpOEIB8upw0hg1ldFP6cqHTJBH1cZqy96OeR3u1dJ+Ez2D4Bg==}
     dev: false
 
   /next-seo/5.5.0_53oqlnqnxhbetdy4ljlkkvmoby:


### PR DESCRIPTION
#174 
```diff
const nextConfig = {
 // ...
}

- module.exports = (_phase, { defaultConfig }) => {
+ module.exports = () => {
    const plugins = [withStaticImport, withBundleAnalyzer, withCustomWebpack]
-   return plugins.reduce((acc, plugin) => plugin(acc), { ...defaultConfig, ...nextConfig})
+   return plugins.reduce((acc, plugin) => plugin(acc), { ...nextConfig })
}
```
の形にすることで解決した