### PR TITLE
今度こそライセンスページをちゃんとエラーハンドリング

### DIFF
--- a/pages/licenses.jsx
+++ b/pages/licenses.jsx
@@ -101,7 +101,7 @@ const getStaticProps = async () => {
       name: pkgName,
       url:
         pkg.homepage ??
-        (pkg.repository.startsWith("https://")
+        (pkg.repository?.startsWith("https://")
           ? pkg.repository
           : `https://www.npmjs.com/package/${pkg.name}`),
       licenses: pkg.licenses,


### PR DESCRIPTION
`pkg.homepage` が falsy でかつ `pkg.repository` が string でないときに `startsWIth` なんてメソッド無いでエラーが出るのを防いだ。